### PR TITLE
Support fastavro deserialization

### DIFF
--- a/avro2py/utils.py
+++ b/avro2py/utils.py
@@ -76,7 +76,7 @@ def from_avro_dict(avro_dict: AvroDictType, record_type: type) -> NamedTuple:
             conversions[field_name] = from_avro_dict(value, record_type=annotation)
 
         elif annotation is UUID:
-            conversions[field_name] = UUID(value)
+            conversions[field_name] = UUID(value) if not isinstance(value, UUID) else value
 
         elif isinstance(annotation, EnumMeta):
             values_to_members = {

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ setup(
     ],
     platforms='any',
     extras_require=extras_require,
-    version="0.0.1",
+    version="0.0.2",
     description='Avro codegen for Python 3.6+',
     author='H. Chase Stevens',
     author_email='chase@chasestevens.com',


### PR DESCRIPTION
Fastavro natively returns UUIDs for the uuid logicaltype. Do not attempt to convert these.