### PR TITLE
Issue #12: Fix codegen for nested avro record

### DIFF
--- a/avro2py/codegen.py
+++ b/avro2py/codegen.py
@@ -8,6 +8,7 @@ from collections import defaultdict
 from contextlib import contextmanager
 from textwrap import wrap
 from typing import NamedTuple, List, Union, Generator, Tuple, Optional, Dict
+from collections import deque
 
 from avro2py.avro_types import (
     Primitives, LogicalTypes, Record, AvroPrimitives, DefinedType, Enum, Array,
@@ -418,9 +419,9 @@ def populate_namespaces(schemas: List[Record]) -> Generator[Tuple[str, ast.Modul
     def frontier_sorting_key(s):
         return s.namespace not in namespace_nodes, s.namespace
 
-    frontier = sorted(schemas, key=frontier_sorting_key)
+    frontier = deque(sorted(schemas, key=frontier_sorting_key))
     while frontier:
-        schema = frontier.pop()
+        schema = frontier.popleft()
         schema_fully_qualified_name = f'{schema.namespace}.{schema.name}'
         if schema_fully_qualified_name in namespace_nodes:
             continue
@@ -441,7 +442,7 @@ def populate_namespaces(schemas: List[Record]) -> Generator[Tuple[str, ast.Modul
             imports=parent_namespace.imports  # n.b. multiple pointers to same object
         )
 
-        frontier = sorted(frontier, key=frontier_sorting_key)
+        frontier = deque(sorted(frontier, key=frontier_sorting_key))
 
     # Sometimes there are implicit namespaces that are children of classes, and
     # hence themselves need to be classes - but have been instantiated as

--- a/avro2py/utils.py
+++ b/avro2py/utils.py
@@ -56,7 +56,7 @@ def _safe_convert_list(v: Union[List, Any]) -> Union[AvroDictType, Any]:
     if isinstance(v, list) and len(v):
         if hasattr(v[0], '_asdict'):
             return [to_avro_dict(ele) for ele in v]
-        elif isinstance(getattr(v[0], '__class__', None), EnumMeta):
+        else:
             return [_convert_types_to_avro(ele) for ele in v]
     return v
 

--- a/avro2py/utils.py
+++ b/avro2py/utils.py
@@ -53,8 +53,11 @@ def _safe_convert_namedtuple(v: Union[NamedTuple, Any]) -> Union[AvroDictType, A
 
 @_CONVERTERS_TO_AVRO.append
 def _safe_convert_list(v: Union[List, Any]) -> Union[AvroDictType, Any]:
-    if isinstance(v, list) and len(v) and hasattr(v[0], '_asdict'):
-        return [to_avro_dict(ele) for ele in v]
+    if isinstance(v, list) and len(v):
+        if hasattr(v[0], '_asdict'):
+            return [to_avro_dict(ele) for ele in v]
+        elif isinstance(getattr(v[0], '__class__', None), EnumMeta):
+            return [_convert_types_to_avro(ele) for ele in v]
     return v
 
 

--- a/example/marketprice/messages/bid.py
+++ b/example/marketprice/messages/bid.py
@@ -1,0 +1,41 @@
+import enum
+from typing import List, NamedTuple
+
+
+class AdgroupCreated(NamedTuple):
+    status: "Status"
+    _original_schema = (
+        '{"type": "record", "name": "AdgroupCreated", "namespace":'
+        ' "marketprice.messages.bid", "fields": [{"name": "status", "type": {"type":'
+        ' "enum", "name": "Status", "doc": "status can be one of Active, Paused",'
+        ' "symbols": ["Active", "Paused"]}}]}'
+    )
+
+
+@enum.unique
+class Status(enum.Enum):
+    ACTIVE = "Active"
+    PAUSED = "Paused"
+
+
+class CampaignCreated(NamedTuple):
+    status: "Status"
+    adgroup: "AdgroupCreated"
+    _original_schema = (
+        '{"type": "record", "name": "CampaignCreated", "namespace":'
+        ' "marketprice.messages.bid", "fields": [{"name": "status", "type": {"type":'
+        ' "enum", "name": "Status", "doc": "status can be one of Active, Paused",'
+        ' "symbols": ["Active", "Paused"]}}, {"name": "adgroup", "type": {"type":'
+        ' "record", "name": "AdgroupCreated", "fields": [{"name": "status", "type":'
+        ' "Status"}]}}]}'
+    )
+
+
+class WallyworldEntity(NamedTuple):
+    tags: List["Status"]
+    _original_schema = (
+        '{"type": "record", "name": "WallyworldEntity", "namespace":'
+        ' "marketprice.messages.bid", "fields": [{"name": "tags", "type": {"type":'
+        ' "array", "items": {"type": "enum", "name": "Status", "doc": "advertising type'
+        ' can be one of Active, Paused", "symbols": ["Active", "Paused"]}}}]}'
+    )

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 astor
-avro
+avro==1.10.2
 black
 hypothesis

--- a/tests/sample_schema.avsc
+++ b/tests/sample_schema.avsc
@@ -1809,5 +1809,68 @@
         }
       }
     ]
+  },
+  {
+    "type": "record",
+    "name": "AdgroupCreated",
+    "namespace": "marketprice.messages.bid",
+    "fields": [
+      {
+        "name": "advertising_type",
+        "type": {
+          "type": "enum",
+          "name": "AdvertisingType",
+          "doc": "advertising type can be one of SponsoredProducts, SponsoredBrands, SponsoredDisplay",
+          "symbols": [
+            "SponsoredProducts",
+            "SponsoredBrands",
+            "SponsoredDisplay"
+          ]
+        }
+      }
+    ]
+  },
+  {
+    "type": "enum",
+    "name": "AdvertisingType",
+    "namespace": "marketprice.messages.bid",
+    "symbols": [
+      "SponsoredProducts",
+      "SponsoredBrands",
+      "SponsoredDisplay"
+    ]
+  },
+  {
+    "type": "record",
+    "name": "CampaignCreated",
+    "namespace": "marketprice.messages.bid",
+    "fields": [
+      {
+        "name": "advertising_type",
+        "type": {
+          "type": "enum",
+          "name": "AdvertisingType",
+          "doc": "advertising type can be one of SponsoredProducts, SponsoredBrands, SponsoredDisplay",
+          "symbols": [
+            "SponsoredProducts",
+            "SponsoredBrands",
+            "SponsoredDisplay"
+          ]
+        }
+      },
+      {
+        "name": "adgroup",
+        "type": {
+          "type": "record",
+          "name": "AdgroupCreated",
+          "fields": [
+            {
+              "name": "advertising_type",
+              "type": "AdvertisingType"
+            }
+          ]
+        }
+      }
+    ]
   }
 ]

--- a/tests/sample_schema.avsc
+++ b/tests/sample_schema.avsc
@@ -1816,15 +1816,14 @@
     "namespace": "marketprice.messages.bid",
     "fields": [
       {
-        "name": "advertising_type",
+        "name": "status",
         "type": {
           "type": "enum",
-          "name": "AdvertisingType",
-          "doc": "advertising type can be one of SponsoredProducts, SponsoredBrands, SponsoredDisplay",
+          "name": "Status",
+          "doc": "status can be one of Active, Paused",
           "symbols": [
-            "SponsoredProducts",
-            "SponsoredBrands",
-            "SponsoredDisplay"
+            "Active",
+            "Paused"
           ]
         }
       }
@@ -1832,12 +1831,11 @@
   },
   {
     "type": "enum",
-    "name": "AdvertisingType",
+    "name": "Status",
     "namespace": "marketprice.messages.bid",
     "symbols": [
-      "SponsoredProducts",
-      "SponsoredBrands",
-      "SponsoredDisplay"
+      "Active",
+      "Paused"
     ]
   },
   {
@@ -1846,15 +1844,14 @@
     "namespace": "marketprice.messages.bid",
     "fields": [
       {
-        "name": "advertising_type",
+        "name": "status",
         "type": {
           "type": "enum",
-          "name": "AdvertisingType",
-          "doc": "advertising type can be one of SponsoredProducts, SponsoredBrands, SponsoredDisplay",
+          "name": "Status",
+          "doc": "status can be one of Active, Paused",
           "symbols": [
-            "SponsoredProducts",
-            "SponsoredBrands",
-            "SponsoredDisplay"
+            "Active",
+            "Paused"
           ]
         }
       },
@@ -1865,10 +1862,32 @@
           "name": "AdgroupCreated",
           "fields": [
             {
-              "name": "advertising_type",
-              "type": "AdvertisingType"
+              "name": "status",
+              "type": "Status"
             }
           ]
+        }
+      }
+    ]
+  },
+  {
+    "type": "record",
+    "name": "WallyworldEntity",
+    "namespace": "marketprice.messages.bid",
+    "fields": [
+      {
+        "name": "tags",
+        "type": {
+          "type": "array",
+          "items": {
+            "type": "enum",
+            "name": "Status",
+            "doc": "advertising type can be one of Active, Paused",
+            "symbols": [
+              "Active",
+              "Paused"
+            ]
+          }
         }
       }
     ]

--- a/tests/test_codegen.py
+++ b/tests/test_codegen.py
@@ -61,7 +61,7 @@ def test_inline_avro_schema_of_nested_record():
 
     # get the variable definition of _original_schema 
     t, = (obj for obj in adgroup_created_class_def.body if isinstance(obj, ast.Assign))
-    _original_schema = t.value.value
+    _original_schema = t.value.s
     # verify that the avro schema of AdGroupCreated should not have not reference.
     schema_dict = json.loads(_original_schema)
     advertising_type = schema_dict['fields'][0]

--- a/tests/test_rendering.py
+++ b/tests/test_rendering.py
@@ -78,6 +78,8 @@ def test_example_message_round_trippable(data):
     note(example_model_dict)
     buffer = io.BytesIO()
     encoder = avro.io.BinaryEncoder(buffer)
+    print('===============', json.dumps(EXAMPLE_AVRO_MODEL_SCHEMA))
+    print('===============ex', example_model_dict)
     datum_writer = avro.io.DatumWriter(avro_parsed_schema)
     datum_writer.write(example_model_dict, encoder)
     buffer.seek(0)

--- a/tests/test_rendering.py
+++ b/tests/test_rendering.py
@@ -78,8 +78,6 @@ def test_example_message_round_trippable(data):
     note(example_model_dict)
     buffer = io.BytesIO()
     encoder = avro.io.BinaryEncoder(buffer)
-    print('===============', json.dumps(EXAMPLE_AVRO_MODEL_SCHEMA))
-    print('===============ex', example_model_dict)
     datum_writer = avro.io.DatumWriter(avro_parsed_schema)
     datum_writer.write(example_model_dict, encoder)
     buffer.seek(0)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -2,6 +2,7 @@
 from hypothesis import given, strategies as st
 
 from avro2py.utils import to_avro_dict
+from example.marketprice.messages.bid import Status, WallyworldEntity
 from example.marketprice.messages.wallyworld.bidder import (
     WallyworldAdGroupStructure, WallyworldAdItem
 )
@@ -85,3 +86,12 @@ def test_to_avro_dict_nested_named_tuples(random_int, requested_at, users_linked
     assert value["advertiserId"] == advertiser_id
     assert value["campaignId"] == campaign_id
     assert value["users_linked"] == users_linked
+
+
+def test_to_avro_dict_list_of_enum():
+    payload = WallyworldEntity(
+        tags=[Status.ACTIVE, Status.PAUSED]
+    )
+    value = to_avro_dict(payload)
+    assert isinstance(value, dict)
+    assert isinstance(value['tags'][0], str)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -15,7 +15,7 @@ from example.marketprice.messages.wallyworld.bidder import (
     requested_at=st.datetimes(),
     users_linked=st.lists(st.uuids(), min_size=0, max_size=33)
 )
-def test_to_avro_dict_nested_named_tuples(random_int, item_id, bid, requested_at, users_linked):
+def test_to_avro_dict_nested_named_tuples_value(random_int, item_id, bid, requested_at, users_linked):
     campaign_id = ad_group_id = advertiser_id = random_int
     payload = WallyworldAdGroupStructure(
         advertiserId=advertiser_id,
@@ -41,7 +41,7 @@ def test_to_avro_dict_nested_named_tuples(random_int, item_id, bid, requested_at
         "campaignId": advertiser_id,
         "adGroupId": advertiser_id,
         "state": "Paused",
-        "users_linked": users_linked,
+        "users_linked": [str(u) for u in users_linked],
         "adItems": [
             {
                 "advertiserId": advertiser_id,
@@ -85,7 +85,7 @@ def test_to_avro_dict_nested_named_tuples(random_int, requested_at, users_linked
 
     assert value["advertiserId"] == advertiser_id
     assert value["campaignId"] == campaign_id
-    assert value["users_linked"] == users_linked
+    assert value["users_linked"] == [str(u) for u in users_linked]
 
 
 def test_to_avro_dict_list_of_enum():
@@ -93,5 +93,4 @@ def test_to_avro_dict_list_of_enum():
         tags=[Status.ACTIVE, Status.PAUSED]
     )
     value = to_avro_dict(payload)
-    assert isinstance(value, dict)
     assert isinstance(value['tags'][0], str)


### PR DESCRIPTION
Consider schemas A, B and C passed as list to `avro2py`, schemas A and B use schema C and B is also nested in A.
```
C: {
}
B: {
   C: {}
}
A: {
    C: {}
    B: {
        C: {"type": "C"}  # reference to A.C
    }
}
```

In the generated class for schema B, the attribute `_original_schema` contains the schema A.C.B instead of B (which is a complete avro schema). 
